### PR TITLE
Feat: 쓰레기통 관련 API 내용 작성

### DIFF
--- a/src/domain/trashcan/trashcan.controller.ts
+++ b/src/domain/trashcan/trashcan.controller.ts
@@ -14,17 +14,6 @@ export class TrashcanController {
   @ApiOperation({
     summary: '특정 좌표를 바탕으로 주위에 있는 쓰레기통의 정보들을 반환받는다.'
   })
-  @Get('/range')
-  async findRange(@Query('x') x: number, @Query('y') y: number): Promise<Trashcan[] | null > {
-    const trashcanData =  await this.trashcanService.findRange(x,y);
-
-    return trashcanData;
-  }
-
-  /* 특정 쓰레기통 정보 가져오기 */
-  @ApiOperation({
-    summary: 'DB에 저장된 쓰레기통 중 특정 ID를 가진 쓰레기통의 정보를 가져온다.'
-  })
   @ApiParam({
     name: 'x',
     description: '사용자의 현재 위도를 쿼리스트링으로 받는다.',
@@ -37,8 +26,19 @@ export class TrashcanController {
     example: '126.973261',
     required: true,
   })
+  @Get('/range')
+  async findRange(@Query('x') x: number, @Query('y') y: number): Promise<Trashcan[] | null> {
+    const trashcanData =  await this.trashcanService.findRange(x,y);
+
+    return trashcanData;
+  }
+
+  /* 특정 쓰레기통 정보 가져오기 */
+  @ApiOperation({
+    summary: 'DB에 저장된 쓰레기통 중 특정 ID를 가진 쓰레기통의 정보를 가져온다.'
+  })
   @Get(':id')
-  async findOne(@Param('id') id: number): Promise<Trashcan> {
+  async findOne(@Param('id') id: number): Promise<Trashcan | null> {
     const trashcanData = await this.trashcanService.findOne(+id);
 
     return trashcanData;

--- a/src/domain/trashcan/trashcan.controller.ts
+++ b/src/domain/trashcan/trashcan.controller.ts
@@ -1,32 +1,86 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
 import { TrashcanService } from './trashcan.service';
 import { CreateTrashcanDto } from '../../dto/trashcan/create-trashcan.dto';
 import { UpdateTrashcanDto } from '../../dto/trashcan/update-trashcan.dto';
+import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { Trashcan } from 'entities/Trashcan';
 
+@ApiTags('Trashcan')
 @Controller('trashcan')
 export class TrashcanController {
   constructor(private readonly trashcanService: TrashcanService) {}
 
+  /* 주위 쓰레기통 정보 가져오기 */
+  @ApiOperation({
+    summary: '특정 좌표를 바탕으로 주위에 있는 쓰레기통의 정보들을 반환받는다.'
+  })
+  @Get('/range')
+  async findRange(@Query('x') x: number, @Query('y') y: number): Promise<Trashcan[] | null > {
+    const trashcanData =  await this.trashcanService.findRange(x,y);
+
+    return trashcanData;
+  }
+
+  /* 특정 쓰레기통 정보 가져오기 */
+  @ApiOperation({
+    summary: 'DB에 저장된 쓰레기통 중 특정 ID를 가진 쓰레기통의 정보를 가져온다.'
+  })
+  @ApiParam({
+    name: 'x',
+    description: '사용자의 현재 위도를 쿼리스트링으로 받는다.',
+    example: '37.576004',
+    required: true,
+  })
+  @ApiParam({
+    name: 'y',
+    description: '사용자의 현재 경도를 쿼리스트링으로 받는다.',
+    example: '126.973261',
+    required: true,
+  })
+  @Get(':id')
+  async findOne(@Param('id') id: number): Promise<Trashcan> {
+    const trashcanData = await this.trashcanService.findOne(+id);
+
+    return trashcanData;
+  }
+
+  /* 쓰레기통 정보 생성 */
+  @ApiOperation({
+    summary: '새 쓰레기통을 생성한다.'
+  })
+  @ApiBody({
+    type: CreateTrashcanDto,
+  })
   @Post()
   create(@Body() createTrashcanDto: CreateTrashcanDto) {
     return this.trashcanService.create(createTrashcanDto);
   }
 
+  /* 쓰레기통 리스트 가져오기 */
+  @ApiOperation({
+    summary: 'DB에 저장된 모든 쓰레기통의 정보를 가져온다.'
+  })
   @Get()
   findAll() {
     return this.trashcanService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.trashcanService.findOne(+id);
-  }
-
+  /* 특정 쓰레기통 정보 업데이트 */
+  @ApiOperation({
+    summary: '특정 ID를 가진 쓰레기통의 정보를 업데이트한다.'
+  })
+  @ApiBody({
+    type: UpdateTrashcanDto,
+  })
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateTrashcanDto: UpdateTrashcanDto) {
     return this.trashcanService.update(+id, updateTrashcanDto);
   }
 
+  /* 특정 쓰레기통 정보 삭제 */
+  @ApiOperation({
+    summary: '특정 ID를 가진 쓰레기통의 정보를 삭제한다.'
+  })
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.trashcanService.remove(+id);

--- a/src/domain/trashcan/trashcan.service.ts
+++ b/src/domain/trashcan/trashcan.service.ts
@@ -1,26 +1,62 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Trashcan } from 'entities/Trashcan';
+import { Repository } from 'typeorm';
 import { CreateTrashcanDto } from '../../dto/trashcan/create-trashcan.dto';
 import { UpdateTrashcanDto } from '../../dto/trashcan/update-trashcan.dto';
 
 @Injectable()
 export class TrashcanService {
-  create(createTrashcanDto: CreateTrashcanDto) {
-    return 'This action adds a new trashcan';
+  constructor(
+    @InjectRepository(Trashcan)
+    private readonly trashcanRepository: Repository<Trashcan>,
+  ) {}
+
+  /* 새 쓰레기통을 DB 내에 생성한다.*/
+  async create(createTrashcanDto: CreateTrashcanDto) {
+    await this.trashcanRepository.save({
+      address: createTrashcanDto.address,
+      type: createTrashcanDto.type,
+      x: createTrashcanDto.x,
+      y: createTrashcanDto.y,
+      });
+    
+    return `This action returns created trashcan`;
   }
 
-  findAll() {
-    return `This action returns all trashcan`;
+  /* DB 내의 모든 쓰레기통을 조회한다. Pagination 적용 예정이긴 한데 해당 함수를 실제로 쓸 일이 있을지는 모르겠음 */
+  async findAll(): Promise<Trashcan[] | null> {
+    return this.trashcanRepository.find();
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} trashcan`;
+  /* 현재 위치를 x, y (위도, 경도)의 매개변수로 받아 그 주변 1km 내의 모든 쓰레기통을 조회한다. */
+  async findRange(x: number, y: number): Promise<Trashcan[] | null> {
+    const qb =  await this.trashcanRepository
+      .createQueryBuilder("Trashcan")
+      .addSelect(`6371 * ACOS(COS(RADIANS(${x}))*COS(RADIANS(X))*COS(RADIANS(Y)-RADIANS(${y}))+SIN(RADIANS(${x}))*SIN(RADIANS(X)))`, "distance")
+      .having(`distance <= 1`)
+      .getMany()
+
+      console.log(qb);
+
+      return qb;
   }
 
-  update(id: number, updateTrashcanDto: UpdateTrashcanDto) {
-    return `This action updates a #${id} trashcan`;
+  /* 어떤 쓰레기통을 클릭하여 정보를 확인하고자 할 경우, 쓰레기통의 ID를 바탕으로 DB에 해당 쓰레기통을 조회하는 Query를 날리게 된다 */
+  async findOne(id: number) : Promise<Trashcan | null> {
+    const result: Trashcan = await this.trashcanRepository.findOneBy({ id : id });
+
+    return result;
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} trashcan`;
+  async update(id: number, updateTrashcanDto: UpdateTrashcanDto): Promise<void> {
+    await this.trashcanRepository.update(
+      id,
+      updateTrashcanDto
+    );
+  }
+
+  async remove(id: number): Promise<void> {
+    await this.trashcanRepository.softDelete(id);
   }
 }

--- a/src/domain/trashcan/trashcan.service.ts
+++ b/src/domain/trashcan/trashcan.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Trashcan } from 'entities/Trashcan';
 import { Repository } from 'typeorm';
@@ -13,15 +13,13 @@ export class TrashcanService {
   ) {}
 
   /* 새 쓰레기통을 DB 내에 생성한다.*/
-  async create(createTrashcanDto: CreateTrashcanDto) {
+  async create(createTrashcanDto: CreateTrashcanDto): Promise<void> {
     await this.trashcanRepository.save({
       address: createTrashcanDto.address,
       type: createTrashcanDto.type,
       x: createTrashcanDto.x,
       y: createTrashcanDto.y,
       });
-    
-    return `This action returns created trashcan`;
   }
 
   /* DB 내의 모든 쓰레기통을 조회한다. Pagination 적용 예정이긴 한데 해당 함수를 실제로 쓸 일이 있을지는 모르겠음 */
@@ -33,22 +31,27 @@ export class TrashcanService {
   async findRange(x: number, y: number): Promise<Trashcan[] | null> {
     const qb =  await this.trashcanRepository
       .createQueryBuilder("Trashcan")
+      .select("Trashcan.id")
+      .addSelect("Trashcan.type")
+      .addSelect("Trashcan.address")
+      .addSelect("Trashcan.x")
+      .addSelect("Trashcan.y") 
       .addSelect(`6371 * ACOS(COS(RADIANS(${x}))*COS(RADIANS(X))*COS(RADIANS(Y)-RADIANS(${y}))+SIN(RADIANS(${x}))*SIN(RADIANS(X)))`, "distance")
       .having(`distance <= 1`)
       .getMany()
-
-      console.log(qb);
-
-      return qb;
+    
+    return qb;
   }
 
   /* 어떤 쓰레기통을 클릭하여 정보를 확인하고자 할 경우, 쓰레기통의 ID를 바탕으로 DB에 해당 쓰레기통을 조회하는 Query를 날리게 된다 */
+  /* 추후 ID 기반이 아닌 좌표를 기반으로도 검색할 수 있도록 수정할 예정 */
   async findOne(id: number) : Promise<Trashcan | null> {
     const result: Trashcan = await this.trashcanRepository.findOneBy({ id : id });
 
     return result;
   }
-
+  
+  // UPDATE
   async update(id: number, updateTrashcanDto: UpdateTrashcanDto): Promise<void> {
     await this.trashcanRepository.update(
       id,
@@ -56,7 +59,10 @@ export class TrashcanService {
     );
   }
 
+  // SOFT DELETE
   async remove(id: number): Promise<void> {
-    await this.trashcanRepository.softDelete(id);
+    await this.trashcanRepository.softDelete(
+      id
+    );
   }
 }

--- a/src/entities/Trashcan.ts
+++ b/src/entities/Trashcan.ts
@@ -29,32 +29,45 @@ export class Trashcan {
     example: '37.576004'
   })
   @Column("decimal", { name: "X", precision: 9, scale: 6 })
-  x: string;
+  x: number;
 
   @ApiProperty({
     description: '쓰레기통의 Y 좌표',
     example: '126.971748'
   })
   @Column("decimal", { name: "Y", precision: 9, scale: 6 })
-  y: string;
+  y: number;
 
   @ApiProperty({
     description: '쓰레기통 정보 생성 날짜'
   })
-  @CreateDateColumn({ type: "timestamp", name: "CREATED_AT" })
+  @CreateDateColumn({
+    type: "timestamp",
+    name: "CREATED_AT",
+    default: "CURRENT_TIMESTAMP"
+  })
   createdAt: Date;
 
   @ApiProperty({
     description: '쓰레기통 정보 최근 수정 날짜'
   })
-  @UpdateDateColumn({ type: "timestamp", name:"UPDATED_AT"})
+  @UpdateDateColumn({
+    type: "timestamp",
+    name:"UPDATED_AT",
+    default: "CURRENT_TIMESTAMP"
+  })
   updatedAt: Date;
 
   @ApiProperty({
     description: '쓰레기통 정보 삭제 날짜'
   })
-  @DeleteDateColumn({ type: "timestamp", name: "DELETED_AT"})
-  deletedAt: Date;
+  @DeleteDateColumn({
+    type: "timestamp",
+    name: "DELETED_AT",
+    nullable: true,
+    default: null
+  })
+  deletedAt: Date | null;
 
   @OneToMany(() => Cleaning, (cleaning) => cleaning.trashcan)
   cleanings: Cleaning[];


### PR DESCRIPTION
## 개요
- 쓰레기통 관련 API 내용 작성

## ⛑ 주의할 점
- 쓰레기통 테이블 스키마가 일부 수정되어, 다른 테이블 엔티티들과 다른 점이 일부 존재합니다. 추후 다른 테이블 API를 작성할 때 수정해줘야 합니다.
- 현재 쓰레기통 검색 범위가 1km로 설정되어 있으며, 이 점은 추후 FE와 상의하여 수정될 수 있습니다.
- findOne 메소드가 현재는 ID를 기반으로 작성되어 있으나, 추후 다양한 데이터를 기반으로 검색할 수 있도록 수정될 예정입니다.
## 🛎 작업 내용
- 쓰레기통 테이블 CRUD 메소드 작성
- 쓰레기통 범위 검색 쿼리 작성
- 쓰레기통 테이블 스키마 일부 수정 (Not null, Default value)
