### PR TITLE
Fix: 올바르지 않은 Column name 수정

### DIFF
--- a/src/domain/trashcan/trashcan.controller.ts
+++ b/src/domain/trashcan/trashcan.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestj
 import { TrashcanService } from './trashcan.service';
 import { CreateTrashcanDto } from '../../dto/trashcan/create-trashcan.dto';
 import { UpdateTrashcanDto } from '../../dto/trashcan/update-trashcan.dto';
-import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Trashcan } from 'entities/Trashcan';
 
 @ApiTags('Trashcan')
@@ -14,21 +14,21 @@ export class TrashcanController {
   @ApiOperation({
     summary: '특정 좌표를 바탕으로 주위에 있는 쓰레기통의 정보들을 반환받는다.'
   })
-  @ApiParam({
-    name: 'x',
+  @ApiQuery({
+    name: 'lat',
     description: '사용자의 현재 위도를 쿼리스트링으로 받는다.',
     example: '37.576004',
     required: true,
   })
-  @ApiParam({
-    name: 'y',
+  @ApiQuery({
+    name: 'lon',
     description: '사용자의 현재 경도를 쿼리스트링으로 받는다.',
     example: '126.973261',
     required: true,
   })
   @Get('/range')
-  async findRange(@Query('x') x: number, @Query('y') y: number): Promise<Trashcan[] | null> {
-    const trashcanData =  await this.trashcanService.findRange(x,y);
+  async findRange(@Query('lat') lat: number, @Query('lon') lon: number): Promise<Trashcan[] | null> {
+    const trashcanData =  await this.trashcanService.findRange(lat,lon);
 
     return trashcanData;
   }

--- a/src/domain/trashcan/trashcan.service.ts
+++ b/src/domain/trashcan/trashcan.service.ts
@@ -17,9 +17,9 @@ export class TrashcanService {
     await this.trashcanRepository.save({
       address: createTrashcanDto.address,
       type: createTrashcanDto.type,
-      x: createTrashcanDto.x,
-      y: createTrashcanDto.y,
-      });
+      latitude: createTrashcanDto.latitude,
+      longitude: createTrashcanDto.longitude,
+    });
   }
 
   /* DB 내의 모든 쓰레기통을 조회한다. Pagination 적용 예정이긴 한데 해당 함수를 실제로 쓸 일이 있을지는 모르겠음 */
@@ -28,15 +28,15 @@ export class TrashcanService {
   }
 
   /* 현재 위치를 x, y (위도, 경도)의 매개변수로 받아 그 주변 1km 내의 모든 쓰레기통을 조회한다. */
-  async findRange(x: number, y: number): Promise<Trashcan[] | null> {
+  async findRange(lat: number, lon: number): Promise<Trashcan[] | null> {
     const qb =  await this.trashcanRepository
       .createQueryBuilder("Trashcan")
       .select("Trashcan.id")
       .addSelect("Trashcan.type")
       .addSelect("Trashcan.address")
-      .addSelect("Trashcan.x")
-      .addSelect("Trashcan.y") 
-      .addSelect(`6371 * ACOS(COS(RADIANS(${x}))*COS(RADIANS(X))*COS(RADIANS(Y)-RADIANS(${y}))+SIN(RADIANS(${x}))*SIN(RADIANS(X)))`, "distance")
+      .addSelect("Trashcan.latitude")
+      .addSelect("Trashcan.longitude") 
+      .addSelect(`6371 * ACOS(COS(RADIANS(${lat}))*COS(RADIANS(LATITUDE))*COS(RADIANS(LONGITUDE)-RADIANS(${lon}))+SIN(RADIANS(${lat}))*SIN(RADIANS(LATITUDE)))`, "distance")
       .having(`distance <= 1`)
       .getMany()
     

--- a/src/dto/trashcan/create-trashcan.dto.ts
+++ b/src/dto/trashcan/create-trashcan.dto.ts
@@ -4,6 +4,6 @@ import { Trashcan } from '../../entities/Trashcan'
 export class CreateTrashcanDto extends PickType(Trashcan, [
     'type',
     'address',
-    'x',
-    'y',
+    'latitude',
+    'longitude',
 ] as const) {}

--- a/src/entities/Application.ts
+++ b/src/entities/Application.ts
@@ -17,18 +17,18 @@ export class Application {
   type: number;
 
   @ApiProperty({
-    description: '현재 사용자의 X 좌표',
+    description: '현재 사용자의 위도',
     example: '37.576004'
   })
-  @Column("decimal", { name: "X", precision: 9, scale: 6 })
-  x: string;
+  @Column("decimal", { name: "LATITUDE", precision: 9, scale: 6 })
+  latitude: string;
 
   @ApiProperty({
-    description: '현재 사용자의 Y 좌표',
+    description: '현재 사용자의 경도',
     example: '126.971748'
   })
-  @Column("decimal", { name: "Y", precision: 9, scale: 6 })
-  y: string;
+  @Column("decimal", { name: "LONGITUDE", precision: 9, scale: 6 })
+  longitude: string;
 
   @ApiProperty({
     description: '정수형으로 표기된 사용자의 요청 사유'

--- a/src/entities/Trashcan.ts
+++ b/src/entities/Trashcan.ts
@@ -25,18 +25,18 @@ export class Trashcan {
   address: string;
 
   @ApiProperty({
-    description: '쓰레기통의 X 좌표',
+    description: '쓰레기통의 위도',
     example: '37.576004'
   })
-  @Column("decimal", { name: "X", precision: 9, scale: 6 })
-  x: number;
+  @Column("decimal", { name: "LATITUDE", precision: 9, scale: 6 })
+  latitude: number;
 
   @ApiProperty({
-    description: '쓰레기통의 Y 좌표',
+    description: '쓰레기통의 경도',
     example: '126.971748'
   })
-  @Column("decimal", { name: "Y", precision: 9, scale: 6 })
-  y: number;
+  @Column("decimal", { name: "LONGITUDE", precision: 9, scale: 6 })
+  longitude: number;
 
   @ApiProperty({
     description: '쓰레기통 정보 생성 날짜'


### PR DESCRIPTION
## 개요
- 올바르지 않은 Column name 수정

## ⛑ 주의할 점
- DB Table이 수정되었으므로 FE-BE간 테스트용으로 사용되던 서버를 현재 버전으로 다시 다운로드해야 합니다.

## 🛎 작업 내용
- DB Table 내 Column name (x, y -> latitude, longitude) 수정
- DB 수정사항에 따른 Application Entity 수정
- DB 수정사항에 따른 Trashcan Entity, Controller, Service 및 Swagger docs 수정