### PR TITLE
Fix: 범위 탐색 쿼리에 조건절 추가

### DIFF
--- a/src/domain/trashcan/trashcan.controller.ts
+++ b/src/domain/trashcan/trashcan.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestj
 import { TrashcanService } from './trashcan.service';
 import { CreateTrashcanDto } from '../../dto/trashcan/create-trashcan.dto';
 import { UpdateTrashcanDto } from '../../dto/trashcan/update-trashcan.dto';
-import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Trashcan } from 'entities/Trashcan';
 
 @ApiTags('Trashcan')
@@ -27,10 +27,13 @@ export class TrashcanController {
     required: true,
   })
   @Get('/range')
-  async findRange(@Query('lat') lat: number, @Query('lon') lon: number): Promise<Trashcan[] | null> {
-    const trashcanData =  await this.trashcanService.findRange(lat,lon);
-
-    return trashcanData;
+  async findRange(@Query('lat') lat: number, @Query('lon') lon: number, @Query('type') type?: number): Promise<Trashcan[] | null> {
+    if (type == null) { 
+      return await this.trashcanService.findRange(lat,lon);
+    }
+    else {
+      return await this.trashcanService.findRange(lat,lon,type);
+    }
   }
 
   /* 특정 쓰레기통 정보 가져오기 */

--- a/src/domain/trashcan/trashcan.controller.ts
+++ b/src/domain/trashcan/trashcan.controller.ts
@@ -26,6 +26,12 @@ export class TrashcanController {
     example: '126.973261',
     required: true,
   })
+  @ApiQuery({
+    name: 'type',
+    description: '사용자가 검색하고자 하는 쓰레기통의 종류를 정수형의 쿼리스트링으로 받는다.',
+    example: '1',
+    required: false,
+  })
   @Get('/range')
   async findRange(@Query('lat') lat: number, @Query('lon') lon: number, @Query('type') type?: number): Promise<Trashcan[] | null> {
     if (type == null) { 


### PR DESCRIPTION
## 개요
- 범위 탐색 쿼리에 조건절 추가

## ⛑ 주의할 점
- 따로 없음

## 🛎 작업 내용
- 범위 탐색을 실시할 때, 특정 Type의 쓰레기통만 검색할 수 있도록 조건절을 추가함
- 추가된 쿼리에 대한 Swagger API Docs 작성
- 범위 탐색 쿼리 코드 재구성