### PR TITLE
Refactor: Custom Repository를 통한 범위 검색 기능 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/swagger": "^5.2.1",
-    "@nestjs/typeorm": "^8.0.3",
+    "@nestjs/typeorm": "^8.0.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "dotenv": "^16.0.0",
@@ -35,7 +35,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "swagger-ui-express": "^4.3.0",
-    "typeorm": "^0.3.5"
+    "typeorm": "^0.2.45"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.2.5",

--- a/src/domain/application/application.service.ts
+++ b/src/domain/application/application.service.ts
@@ -29,7 +29,7 @@ export class ApplicationService {
   
   /* DB에서 특정 ID의 쓰레기통 추가신청을 조회한다. */
   async findOne(id: number) : Promise<Application | null> {
-    return this.applicationRepository.findOneBy({id : id});
+    return this.applicationRepository.findOne(id);
   }
 
   //update

--- a/src/domain/cleaning/cleaning.service.ts
+++ b/src/domain/cleaning/cleaning.service.ts
@@ -27,7 +27,7 @@ export class CleaningService {
 
   /* DB에서 특정 ID를 가진 청소 신청을 조회한다. */
   findOne(id: number) : Promise<Cleaning | null> {
-    return this.cleaningRepository.findOneBy({id : id});
+    return this.cleaningRepository.findOne(id);
   }
 
   // UPDATE

--- a/src/domain/trashcan/trashcan.controller.ts
+++ b/src/domain/trashcan/trashcan.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestj
 import { TrashcanService } from './trashcan.service';
 import { CreateTrashcanDto } from '../../dto/trashcan/create-trashcan.dto';
 import { UpdateTrashcanDto } from '../../dto/trashcan/update-trashcan.dto';
-import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Trashcan } from 'entities/Trashcan';
 
 @ApiTags('Trashcan')

--- a/src/domain/trashcan/trashcan.controller.ts
+++ b/src/domain/trashcan/trashcan.controller.ts
@@ -33,12 +33,12 @@ export class TrashcanController {
     required: false,
   })
   @Get('/range')
-  async findRange(@Query('lat') lat: number, @Query('lon') lon: number, @Query('type') type?: number): Promise<Trashcan[] | null> {
+  async findAllByRange(@Query('lat') lat: number, @Query('lon') lon: number, @Query('type') type?: number): Promise<Trashcan[] | null> {
     if (type == null) { 
-      return await this.trashcanService.findRange(lat,lon);
+      return await this.trashcanService.findAllByRange(lat,lon);
     }
     else {
-      return await this.trashcanService.findRange(lat,lon,type);
+      return await this.trashcanService.findAllByRange(lat,lon,type);
     }
   }
 
@@ -64,8 +64,8 @@ export class TrashcanController {
     required: true,
   })
   @Get('/nearest')
-  async findNearestOne(@Query('lat') lat: number, @Query('lon') lon: number, @Query('type') type: number) {
-    return await this.trashcanService.findNearestOne(lat, lon, type);
+  async findOneByRange(@Query('lat') lat: number, @Query('lon') lon: number, @Query('type') type: number) {
+    return await this.trashcanService.findOneByRange(lat, lon, type);
   }
 
   /* 특정 쓰레기통 정보 가져오기 */

--- a/src/domain/trashcan/trashcan.module.ts
+++ b/src/domain/trashcan/trashcan.module.ts
@@ -2,11 +2,11 @@ import { Module } from '@nestjs/common';
 import { TrashcanService } from './trashcan.service';
 import { TrashcanController } from './trashcan.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Trashcan } from 'entities/Trashcan';
+import { TrashcanRepository } from './trashcan.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Trashcan])],
+  imports: [TypeOrmModule.forFeature([TrashcanRepository])],
   controllers: [TrashcanController],
-  providers: [TrashcanService]
+  providers: [TrashcanService],
 })
 export class TrashcanModule {}

--- a/src/domain/trashcan/trashcan.repository.ts
+++ b/src/domain/trashcan/trashcan.repository.ts
@@ -1,0 +1,41 @@
+import { Trashcan } from "entities/Trashcan";
+import { EntityRepository, Repository } from "typeorm";
+
+@EntityRepository(Trashcan)
+export class TrashcanRepository extends Repository<Trashcan> {
+    async findAllByRange(lat: number, lon: number, type?: number) {
+        const qb = this.createQueryBuilder("Trashcan")
+            .select([
+                'Trashcan.id',
+                'Trashcan.type',
+                'Trashcan.address',
+                'Trashcan.latitude',
+                'Trashcan.longitude'
+            ])
+            .addSelect(`6371 * ACOS(COS(RADIANS(${lat}))*COS(RADIANS(LATITUDE))*COS(RADIANS(LONGITUDE)-RADIANS(${lon}))+SIN(RADIANS(${lat}))*SIN(RADIANS(LATITUDE)))`, "distance")
+            .having('distance < 1')
+            .addOrderBy('distance', 'ASC');
+                
+        if (type) {
+            qb.andWhere('Trashcan.type = :type', { type });
+        }
+                  
+        return await qb.getMany();
+    }
+
+    async findOneByRange(lat: number, lon: number, type: number) {
+        return await this.createQueryBuilder("Trashcan")
+            .select([
+                'Trashcan.id',
+                'Trashcan.type',
+                'Trashcan.address',
+                'Trashcan.latitude',
+                'Trashcan.longitude'
+            ])
+            .addSelect(`6371 * ACOS(COS(RADIANS(${lat}))*COS(RADIANS(LATITUDE))*COS(RADIANS(LONGITUDE)-RADIANS(${lon}))+SIN(RADIANS(${lat}))*SIN(RADIANS(LATITUDE)))`, "distance")
+            .where('Trashcan.type = :type', { type })
+            .having('distance < 1')
+            .addOrderBy('distance', 'ASC')
+            .getOne();
+    }
+}

--- a/src/domain/trashcan/trashcan.service.ts
+++ b/src/domain/trashcan/trashcan.service.ts
@@ -1,15 +1,16 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Trashcan } from 'entities/Trashcan';
-import { Repository } from 'typeorm';
 import { CreateTrashcanDto } from '../../dto/trashcan/create-trashcan.dto';
 import { UpdateTrashcanDto } from '../../dto/trashcan/update-trashcan.dto';
+import { TrashcanRepository } from './trashcan.repository';
+
 
 @Injectable()
 export class TrashcanService {
   constructor(
-    @InjectRepository(Trashcan)
-    private readonly trashcanRepository: Repository<Trashcan>,
+    @InjectRepository(TrashcanRepository)
+    private readonly trashcanRepository: TrashcanRepository,
   ) {}
 
   /* 새 쓰레기통을 DB 내에 생성한다.*/
@@ -29,23 +30,11 @@ export class TrashcanService {
 
   /* 현재 위치를 x, y (위도, 경도)의 매개변수로 받아 그 주변 1km 내의 모든 쓰레기통을 조회한다. */
   async findRange(lat: number, lon: number, type? : number): Promise<Trashcan[] | null> {
-    const qb =  await this.trashcanRepository
-      .createQueryBuilder("Trashcan")
-      .select([
-        'Trashcan.id',
-        'Trashcan.type',
-        'Trashcan.address',
-        'Trashcan.latitude',
-        'Trashcan.longitude'
-      ])
-      .addSelect(`6371 * ACOS(COS(RADIANS(${lat}))*COS(RADIANS(LATITUDE))*COS(RADIANS(LONGITUDE)-RADIANS(${lon}))+SIN(RADIANS(${lat}))*SIN(RADIANS(LATITUDE)))`, "distance")
-      .having('distance < 1');
-
     if (type) {
-      qb.andWhere('Trashcan.type = :type', { type });
+      return this.trashcanRepository.findAllByRange(lat, lon, type);
     }
-    
-    return qb.getMany();
+
+    return this.trashcanRepository.findAllByRange(lat,lon);    
   }
 
   /* 어떤 쓰레기통을 클릭하여 정보를 확인하고자 할 경우, 쓰레기통의 ID를 바탕으로 DB에 해당 쓰레기통을 조회하는 Query를 날리게 된다 */
@@ -66,21 +55,7 @@ export class TrashcanService {
   }
 
   async findNearestOne(lat: number, lon: number, type: number) : Promise<Trashcan | null> {
-    const qb = await this.trashcanRepository
-      .createQueryBuilder("Trashcan")
-      .select([
-        'Trashcan.id',
-        'Trashcan.type',
-        'Trashcan.address',
-        'Trashcan.latitude',
-        'Trashcan.longitude'
-      ])
-      .addSelect(`6371 * ACOS(COS(RADIANS(${lat}))*COS(RADIANS(LATITUDE))*COS(RADIANS(LONGITUDE)-RADIANS(${lon}))+SIN(RADIANS(${lat}))*SIN(RADIANS(LATITUDE)))`, "distance")
-      .where('Trashcan.type = :type', { type })
-      .having('distance < 1')
-      .addOrderBy('distance', 'ASC')
-
-    return qb.getOne();
+    return this.trashcanRepository.findOneByRange(lat, lon, type);
   }
   
   // UPDATE

--- a/src/domain/trashcan/trashcan.service.ts
+++ b/src/domain/trashcan/trashcan.service.ts
@@ -29,7 +29,7 @@ export class TrashcanService {
   }
 
   /* 현재 위치를 x, y (위도, 경도)의 매개변수로 받아 그 주변 1km 내의 모든 쓰레기통을 조회한다. */
-  async findRange(lat: number, lon: number, type? : number): Promise<Trashcan[] | null> {
+  async findAllByRange(lat: number, lon: number, type? : number): Promise<Trashcan[] | null> {
     if (type) {
       return this.trashcanRepository.findAllByRange(lat, lon, type);
     }
@@ -54,7 +54,7 @@ export class TrashcanService {
     return qb.getOne();
   }
 
-  async findNearestOne(lat: number, lon: number, type: number) : Promise<Trashcan | null> {
+  async findOneByRange(lat: number, lon: number, type: number) : Promise<Trashcan | null> {
     return this.trashcanRepository.findOneByRange(lat, lon, type);
   }
   

--- a/src/dto/trashcan/create-trashcan.dto.ts
+++ b/src/dto/trashcan/create-trashcan.dto.ts
@@ -1,6 +1,6 @@
 import { PickType } from '@nestjs/swagger'
 import { Trashcan } from '../../entities/Trashcan'
-import { IsIn, IsLatitude, IsLongitude, IsNumber } from 'class-validator';
+import { IsIn, IsLatitude, IsLongitude, IsNumber, IsString } from 'class-validator';
 export class CreateTrashcanDto extends PickType(Trashcan, [
     'type',
     'address',
@@ -11,6 +11,9 @@ export class CreateTrashcanDto extends PickType(Trashcan, [
     @IsIn([1,2])
     type: number;
 
+    @IsString()
+    address: string;
+
     @IsNumber()
     @IsLatitude()
     latitude: number;
@@ -18,8 +21,4 @@ export class CreateTrashcanDto extends PickType(Trashcan, [
     @IsNumber()
     @IsLongitude()
     longitude: number;
-
-    @IsNumber()
-    @IsIn([1,2,3])
-    note: number;
 }


### PR DESCRIPTION
## 개요
- Custom Repository를 통한 범위 검색 기능 분리

## ⛑ 주의할 점
### Typeorm, Nestjs@typeorm의 버전을 다운그레이드 하였습니다.
- Typeorm은 0.2.45 버전을 사용합니다.
- nestjs@typeorm은 8.0.2 버전을 사용합니다.
- 이에 따라, 배포중인 서버의 모듈을 삭제한 후 해당 버전으로 재설치 하는 과정이 필요합니다.

## 🛎 작업 내용
- Custom Repository 기능을 활용하여 Trashcan Service 파일 내 범위 검색 세부 구현을 Repository 파일로 따로 분리하였습니다.
- Typeorm과 nestjs@typeorm의 버전 변경에 따라 findOneBy 함수를 fineOne(ID)와 같은 형태로 수정하였습니다.
- 쓰레기통 Object를 생성할 때 Class-validator가 제대로 작동하지 않는 부분을 수정하였습니다.
