### PR TITLE
Fix: Log search by Trashcan-ID

### DIFF
--- a/src/domain/trashcan-full-log/trashcan-full-log.service.ts
+++ b/src/domain/trashcan-full-log/trashcan-full-log.service.ts
@@ -33,8 +33,7 @@ export class TrashcanFullLogService {
         const qb = this.trashcanFullLogRepository
                     .createQueryBuilder("TrashcanFullLog")
                     .select([
-                        'TrashcanFullLog.id',
-                        'TrashcanFullLog.isFull',
+                        'TrashcanFullLog.id'
                     ])
                     .andWhere('TrashcanFullLog.trashcanId = :id', { id });
 


### PR DESCRIPTION
## 개요
- 쓰레기통 ID 기반 쓰레기통 꽉 참 로그 검색 쿼리 수정

## ⛑ 주의할 점
- 따로 없습니다.

## 🛎 작업 내용
- 쓰레기통 ID 기반 쓰레기통 꽉 참 로그 검색 쿼리에 isFull 컬럼이 삭제되지 않은 버그가 수정되었습니다.
